### PR TITLE
Add 'massetto' to Italian dictionary

### DIFF
--- a/extension/dictionaries/it_IT.dic
+++ b/extension/dictionaries/it_IT.dic
@@ -50702,6 +50702,7 @@ masseria/Q
 masserizia/Q
 massese/S
 massetere/S
+massetto
 masseuse
 massicci
 massiccia/n


### PR DESCRIPTION
https://www.treccani.it/enciclopedia/massetto/